### PR TITLE
fix small nits in precommit-basic document

### DIFF
--- a/precommit/docs/precommit-basic.md
+++ b/precommit/docs/precommit-basic.md
@@ -32,12 +32,13 @@ This is a modification to Hadoop's version of test-patch so that we may bring to
 
 test-patch has the following requirements:
 
-* Maven-based project (and maven installed)
+* Ant- or Maven-based project (and ant/maven installed)
 * git-based project (and git installed)
-* bash v3.x or higher
+* bash v3.2 or higher
 * findbugs 3.x installed
 * shellcheck installed
 * GNU diff
+* GNU patch
 * POSIX awk
 * POSIX grep
 * POSIX sed
@@ -92,7 +93,7 @@ We used two new options here.  --basedir sets the location of the repository to 
 
 After the tests have run, there is a directory that contains all of the test-patch related artifacts.  This is generally referred to as the patchprocess directory.  By default, test-patch tries to make something off of /tmp to contain this content.  Using the `--patchdir` command, one can specify exactly which directory to use.  This is helpful for automated precommit testing so that the Jenkins or other automated workflow system knows where to look to gather up the output.
 
-## Provinding Patch Files
+## Providing Patch Files
 
 It is a fairly common practice within the Apache community to use Apache's JIRA instance to store potential patches.  As a result, test-patch supports providing just a JIRA issue number.  test-patch will find the *last* attachment, download it, then process it.
 

--- a/precommit/main/test-patch.sh
+++ b/precommit/main/test-patch.sh
@@ -86,7 +86,7 @@ function setup_defaults
       GIT=${GIT:-git}
       EGREP=${EGREP:-/usr/xpg4/bin/egrep}
       GREP=${GREP:-/usr/xpg4/bin/grep}
-      PATCH=${PATCH:-patch}
+      PATCH=${PATCH:-/usr/gnu/bin/patch}
       DIFF=${DIFF:-/usr/gnu/bin/diff}
       FILE=${FILE:-file}
     ;;
@@ -930,6 +930,18 @@ function parse_args
   fi
 
   GITDIFFLINES=${PATCH_DIR}/gitdifflines.txt
+}
+
+## @description  Check execution environment such as software versions
+## @audience     private
+## @stability    evolving
+## @replaceable  no
+function check_environment
+{
+  if [[ $BASH_VERSION < "3.2" ]]; then
+    yetus_error "Bash 3.2+ is required."
+    exit 1
+  fi
 }
 
 ## @description  Locate the pom.xml file for a given directory
@@ -2935,6 +2947,8 @@ big_console_header "Bootstrapping test harness"
 setup_defaults
 
 parse_args "$@"
+
+check_environment
 
 importplugins
 

--- a/precommit/main/test-patch.sh
+++ b/precommit/main/test-patch.sh
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Make sure that bash version meets the pre-requisite
+if [[ ${BASH_VERSION} < "3.2" ]]; then
+  echo "Bash 3.2+ is required."
+  exit 1
+fi
+
 ### BUILD_URL is set by Hudson if it is run by patch process
 
 this="${BASH_SOURCE-$0}"
@@ -21,42 +27,6 @@ BINDIR=$(cd -P -- "$(dirname -- "${this}")" >/dev/null && pwd -P)
 CWD=$(pwd)
 USER_PARAMS=("$@")
 GLOBALTIMER=$(date +"%s")
-
-## @description  Print a message to stderr
-## @audience     public
-## @stability    stable
-## @replaceable  no
-## @param        string
-function yetus_error
-{
-  echo "$*" 1>&2
-}
-
-## @description  Print a message to stderr if --debug is turned on
-## @audience     public
-## @stability    stable
-## @replaceable  no
-## @param        string
-function yetus_debug
-{
-  if [[ -n "${TP_SHELL_SCRIPT_DEBUG}" ]]; then
-    echo "[$(date) DEBUG]: $*" 1>&2
-  fi
-}
-
-## @description  Make sure that bash version meets the pre-requisite
-## @audience     private
-## @stability    stable
-## @replaceable  no
-function check_bash_version
-{
-  if [[ ${BASH_VERSION} < "3.2" ]]; then
-    yetus_error "Bash 3.2+ is required."
-    exit 1
-  fi
-}
-
-check_bash_version
 
 ## @description  Setup the default global variables
 ## @audience     public
@@ -147,6 +117,28 @@ function setup_defaults
   TP_FOOTER_COUNTER=0
 
   RESULT=0
+}
+
+## @description  Print a message to stderr
+## @audience     public
+## @stability    stable
+## @replaceable  no
+## @param        string
+function yetus_error
+{
+  echo "$*" 1>&2
+}
+
+## @description  Print a message to stderr if --debug is turned on
+## @audience     public
+## @stability    stable
+## @replaceable  no
+## @param        string
+function yetus_debug
+{
+  if [[ -n "${TP_SHELL_SCRIPT_DEBUG}" ]]; then
+    echo "[$(date) DEBUG]: $*" 1>&2
+  fi
 }
 
 ## @description  Convert the given module name to a file fragment

--- a/precommit/main/test-patch.sh
+++ b/precommit/main/test-patch.sh
@@ -670,7 +670,7 @@ function testpatch_usage
   echo "--git-cmd=<cmd>        The 'git' command to use (default 'git')"
   echo "--grep-cmd=<cmd>       The 'grep' command to use (default 'grep')"
   echo "--mvn-cmd=<cmd>        The 'mvn' command to use (default \${MAVEN_HOME}/bin/mvn, or 'mvn')"
-  echo "--patch-cmd=<cmd>      The 'patch' command to use (default 'patch')"
+  echo "--patch-cmd=<cmd>      The GNU-compatible 'patch' command to use (default 'patch')"
   echo "--ps-cmd=<cmd>         The 'ps' command to use (default 'ps')"
   echo "--sed-cmd=<cmd>        The 'sed' command to use (default 'sed')"
 

--- a/precommit/main/test-patch.sh
+++ b/precommit/main/test-patch.sh
@@ -22,6 +22,42 @@ CWD=$(pwd)
 USER_PARAMS=("$@")
 GLOBALTIMER=$(date +"%s")
 
+## @description  Print a message to stderr
+## @audience     public
+## @stability    stable
+## @replaceable  no
+## @param        string
+function yetus_error
+{
+  echo "$*" 1>&2
+}
+
+## @description  Print a message to stderr if --debug is turned on
+## @audience     public
+## @stability    stable
+## @replaceable  no
+## @param        string
+function yetus_debug
+{
+  if [[ -n "${TP_SHELL_SCRIPT_DEBUG}" ]]; then
+    echo "[$(date) DEBUG]: $*" 1>&2
+  fi
+}
+
+## @description  Make sure that bash version meets the pre-requisite
+## @audience     private
+## @stability    stable
+## @replaceable  no
+function check_bash_version
+{
+  if [[ ${BASH_VERSION} < "3.2" ]]; then
+    yetus_error "Bash 3.2+ is required."
+    exit 1
+  fi
+}
+
+check_bash_version
+
 ## @description  Setup the default global variables
 ## @audience     public
 ## @stability    stable
@@ -111,28 +147,6 @@ function setup_defaults
   TP_FOOTER_COUNTER=0
 
   RESULT=0
-}
-
-## @description  Print a message to stderr
-## @audience     public
-## @stability    stable
-## @replaceable  no
-## @param        string
-function yetus_error
-{
-  echo "$*" 1>&2
-}
-
-## @description  Print a message to stderr if --debug is turned on
-## @audience     public
-## @stability    stable
-## @replaceable  no
-## @param        string
-function yetus_debug
-{
-  if [[ -n "${TP_SHELL_SCRIPT_DEBUG}" ]]; then
-    echo "[$(date) DEBUG]: $*" 1>&2
-  fi
 }
 
 ## @description  Convert the given module name to a file fragment
@@ -926,18 +940,6 @@ function parse_args
   fi
 
   GITDIFFLINES=${PATCH_DIR}/gitdifflines.txt
-}
-
-## @description  Check execution environment such as software versions
-## @audience     private
-## @stability    evolving
-## @replaceable  no
-function check_environment
-{
-  if [[ $BASH_VERSION < "3.2" ]]; then
-    yetus_error "Bash 3.2+ is required."
-    exit 1
-  fi
 }
 
 ## @description  Locate the pom.xml file for a given directory
@@ -2943,8 +2945,6 @@ big_console_header "Bootstrapping test harness"
 setup_defaults
 
 parse_args "$@"
-
-check_environment
 
 importplugins
 


### PR DESCRIPTION
* Ant is also supported as a build tool (but I don't know if there is such a project...)
* bash 3.2+ is needed, because the right side of a regex operator (=~) must be quoted on v3.1 or lower
* GNU patch is needed as the fallback from git
* typo fixed